### PR TITLE
Refactor SimpleJSON to only allow string values

### DIFF
--- a/pkg/zkcertificate/certificate_simple_json.go
+++ b/pkg/zkcertificate/certificate_simple_json.go
@@ -25,8 +25,8 @@ import (
 )
 
 // SimpleJSON represents the input data for data that consists of
-// simple JSON fields: strings, numbers, and booleans.
-type SimpleJSON map[string]interface{}
+// simple JSON fields: strings only.
+type SimpleJSON map[string]string
 
 // FFEncode implements FFEncoder.
 func (c SimpleJSON) FFEncode() (SimpleJSONContent, error) {
@@ -40,20 +40,8 @@ func (c SimpleJSON) FFEncode() (SimpleJSONContent, error) {
 
 	for i, key := range keys {
 		value := c[key]
-		var valueStr string
 
-		switch v := value.(type) {
-		case string:
-			valueStr = v
-		case float64:
-			valueStr = fmt.Sprintf("%v", v)
-		case bool:
-			valueStr = fmt.Sprintf("%t", v)
-		default:
-			return nil, fmt.Errorf("unsupported type for field %s: %T", key, v)
-		}
-
-		hash, err := poseidon.HashBytes([]byte(valueStr))
+		hash, err := poseidon.HashBytes([]byte(value))
 		if err != nil {
 			return nil, fmt.Errorf("hash field %s: %w", key, err)
 		}
@@ -65,36 +53,17 @@ func (c SimpleJSON) FFEncode() (SimpleJSONContent, error) {
 
 // Validate performs validation on the SimpleJSON instance.
 func (c *SimpleJSON) Validate() error {
-	if c == nil {
-		return nil
-	}
-
-	for key, value := range *c {
-		switch value.(type) {
-		case string, float64, bool:
-			// If the value is of an expected type, no action is needed.
-		default:
-			return fmt.Errorf("unsupported type for field %s: %T", key, value)
-		}
-	}
-
 	return nil
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (c *SimpleJSON) UnmarshalJSON(data []byte) error {
-	var tempMap map[string]interface{}
+	var tempMap map[string]string
 	if err := json.Unmarshal(data, &tempMap); err != nil {
 		return err
 	}
 
-	tempSimpleJSON := SimpleJSON(tempMap)
-
-	if err := tempSimpleJSON.Validate(); err != nil {
-		return err
-	}
-
-	*c = tempSimpleJSON
+	*c = SimpleJSON(tempMap)
 	return nil
 }
 

--- a/pkg/zkcertificate/certificate_simple_json_test.go
+++ b/pkg/zkcertificate/certificate_simple_json_test.go
@@ -27,9 +27,9 @@ import (
 func TestSimpleJSON_Validate(t *testing.T) {
 	simpleJSON := zkcertificate.SimpleJSON{
 		"name":      "John Doe",
-		"age":       float64(30),
-		"isMarried": true,
-		"height":    1.75,
+		"age":       "30",
+		"isMarried": "true",
+		"height":    "1.75",
 		"birthday":  "1990-01-01T00:00:00Z",
 	}
 
@@ -39,9 +39,9 @@ func TestSimpleJSON_Validate(t *testing.T) {
 func TestSimpleJSON_FFEncode(t *testing.T) {
 	simpleJSON := zkcertificate.SimpleJSON{
 		"name":      "John Doe",
-		"age":       float64(30),
-		"isMarried": true,
-		"height":    1.75,
+		"age":       "30",
+		"isMarried": "true",
+		"height":    "1.75",
 		"birthday":  "1990-01-01T00:00:00Z",
 	}
 
@@ -74,9 +74,9 @@ func TestSimpleJSONContent_Hash(t *testing.T) {
 func TestSimpleJSON_UnmarshalJSON(t *testing.T) {
 	jsonData := `{
 		"name": "John Doe",
-		"age": 30,
-		"isMarried": true,
-		"height": 1.75,
+		"age": "30",
+		"isMarried": "true",
+		"height": "1.75",
 		"birthday": "1990-01-01T00:00:00Z"
 	}`
 
@@ -86,51 +86,12 @@ func TestSimpleJSON_UnmarshalJSON(t *testing.T) {
 
 	expected := zkcertificate.SimpleJSON{
 		"name":      "John Doe",
-		"age":       float64(30),
-		"isMarried": true,
-		"height":    1.75,
+		"age":       "30",
+		"isMarried": "true",
+		"height":    "1.75",
 		"birthday":  "1990-01-01T00:00:00Z",
 	}
 	require.Equal(t, expected, simpleJSON)
-}
-
-func TestSimpleJSON_Validate_Negative(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   *zkcertificate.SimpleJSON
-		wantErr bool
-	}{
-		{name: "Unsupported Types", input: &zkcertificate.SimpleJSON{"unsupported": []int{1, 2, 3}}, wantErr: true},
-		{name: "Nil JSON", input: nil, wantErr: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.input.Validate()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("SimpleJSON.Validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestSimpleJSON_FFEncode_Negative(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   zkcertificate.SimpleJSON
-		wantErr bool
-	}{
-		{name: "Unsupported Types", input: zkcertificate.SimpleJSON{"unsupported": make(chan int)}, wantErr: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.input.FFEncode()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("SimpleJSON.FFEncode() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
 }
 
 func TestSimpleJSON_UnmarshalJSON_Negative(t *testing.T) {


### PR DESCRIPTION
Hey @HarmlessEvil 
Please take a look at another PR.

- The underlying type of `SimpleJSON` is now `map[string]string` instead of `map[string]interface{}`, allowing only string values.
- The `FFEncode` method now directly hashes the string values without any type conversion.
- The `Validate` method is "removed" since it's no longer needed as we only allow string values.
- The `UnmarshalJSON` method is simplified to directly unmarshal the JSON data into a map[string]string.

By using `map[string]string`, we ensure that the input values are consistently represented as strings throughout the code. This eliminates the issues related to floating-point precision and inconsistent hashing of different value types.

The updated code should provide a more reliable and consistent implementation of `SimpleJSON`.