### PR TITLE
Chain-id field for zkCert registrations

### DIFF
--- a/cmd/issueZKCert.go
+++ b/cmd/issueZKCert.go
@@ -110,7 +110,7 @@ func issueZKCert(f *issueZKCertFlags) error {
 
 	chainID, err := client.ChainID(ctx)
 	if err != nil {
-		return fmt.Errorf("could not retrieve chain-id: %w", err)
+		return fmt.Errorf("retrieve chain-id: %w", err)
 	}
 
 	registryAddress := f.registryAddress.Address()

--- a/cmd/issueZKCert.go
+++ b/cmd/issueZKCert.go
@@ -108,6 +108,11 @@ func issueZKCert(f *issueZKCertFlags) error {
 		return fmt.Errorf("connect to blockchain rpc: %w", err)
 	}
 
+	chainID, err := client.ChainID(ctx)
+	if err != nil {
+		return fmt.Errorf("could not retrieve chain-id: %w", err)
+	}
+
 	registryAddress := f.registryAddress.Address()
 
 	registry, err := contracts.NewZkCertificateRegistry(registryAddress, client)
@@ -144,7 +149,7 @@ func issueZKCert(f *issueZKCertFlags) error {
 		return fmt.Errorf("encode registration transaction to json: %w", err)
 	}
 
-	if err := buildAndSaveOutput(f.outputFilePath, certificate, registryAddress, emptyLeafIndex, proof); err != nil {
+	if err := buildAndSaveOutput(f.outputFilePath, certificate, registryAddress, chainID, emptyLeafIndex, proof); err != nil {
 		return fmt.Errorf("collect output: %w", err)
 	}
 
@@ -274,6 +279,7 @@ func buildAndSaveOutput[T any](
 	outputFilePath string,
 	certificate zkcertificate.Certificate[T],
 	registryAddress common.Address,
+	chainID int,
 	leafIndex int,
 	proof merkle.Proof,
 ) error {
@@ -281,6 +287,7 @@ func buildAndSaveOutput[T any](
 		Certificate: certificate,
 		Registration: zkcertificate.RegistrationDetails{
 			Address:   registryAddress,
+			ChainID:   chainID,
 			Revocable: true,
 			LeafIndex: leafIndex,
 		},

--- a/cmd/issueZKCert.go
+++ b/cmd/issueZKCert.go
@@ -279,7 +279,7 @@ func buildAndSaveOutput[T any](
 	outputFilePath string,
 	certificate zkcertificate.Certificate[T],
 	registryAddress common.Address,
-	chainID int,
+	chainID *big.Int,
 	leafIndex int,
 	proof merkle.Proof,
 ) error {

--- a/pkg/zkcertificate/certificate.go
+++ b/pkg/zkcertificate/certificate.go
@@ -175,7 +175,7 @@ type IssuedCertificate[T any] struct {
 // RegistrationDetails represents details related to the registration of a certificate.
 type RegistrationDetails struct {
 	Address   common.Address `json:"address"`
-	ChainID   int            `json:"chainID"`
+	ChainID   *big.Int       `json:"chainID"`
 	Revocable bool           `json:"revocable"`
 	LeafIndex int            `json:"leafIndex"`
 }

--- a/pkg/zkcertificate/certificate.go
+++ b/pkg/zkcertificate/certificate.go
@@ -175,6 +175,7 @@ type IssuedCertificate[T any] struct {
 // RegistrationDetails represents details related to the registration of a certificate.
 type RegistrationDetails struct {
 	Address   common.Address `json:"address"`
+	ChainID   int            `json:"chainID"`
 	Revocable bool           `json:"revocable"`
 	LeafIndex int            `json:"leafIndex"`
 }


### PR DESCRIPTION
Adjusting the GuardianSDK according to https://github.com/Galactica-corp/galactica-monorepo/pull/51

- New field `chainID` in registration data of an issued zkCertificate