### PR TITLE
fix: Remove unused imports

### DIFF
--- a/pkg/merkle/tree.go
+++ b/pkg/merkle/tree.go
@@ -19,11 +19,9 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"math/big"
 
 	"github.com/Galactica-corp/merkle-proof-service/gen/galactica/merkle"
 	"github.com/holiman/uint256"
-	"github.com/iden3/go-iden3-crypto/poseidon"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"


### PR DESCRIPTION
This pull request addresses compilation errors in the pkg/merkle/tree.go file by removing unused imports:

- Removed import of "math/big" package
- Removed import of "github.com/iden3/go-iden3-crypto/poseidon" package

to prevent these errors from happening:

```sh
# github.com/galactica-corp/guardians-sdk/pkg/merkle
../../go/pkg/mod/github.com/galactica-corp/guardians-sdk@v1.8.0/pkg/merkle/tree.go:22:2: "math/big" imported and not used
../../go/pkg/mod/github.com/galactica-corp/guardians-sdk@v1.8.0/pkg/merkle/tree.go:26:2: "github.com/iden3/go-iden3-crypto/poseidon" imported and not used
```