### PR TITLE
zkCertificate: alphabetical ordering for hashes

### DIFF
--- a/pkg/zkcertificate/certificate.go
+++ b/pkg/zkcertificate/certificate.go
@@ -236,15 +236,16 @@ func LeafHash(
 	expirationDate time.Time,
 ) (Hash, error) {
 	hash, err := poseidon.Hash([]*big.Int{
+		// fields ordered alphabetically regarding their JSON key in the circuit
 		contentHash.BigInt(),
+		big.NewInt(expirationDate.Unix()),
+		commitmentHash.BigInt(),
 		providerPublicKey.X,
 		providerPublicKey.Y,
-		signature.S,
 		signature.R8.X,
 		signature.R8.Y,
-		commitmentHash.BigInt(),
+		signature.S,
 		big.NewInt(salt),
-		big.NewInt(expirationDate.Unix()),
 	})
 	if err != nil {
 		return Hash{}, fmt.Errorf("compute leaf hash: %w", err)

--- a/pkg/zkcertificate/certificate_exchange.go
+++ b/pkg/zkcertificate/certificate_exchange.go
@@ -87,10 +87,11 @@ type ExchangeContent struct {
 // Hash implements Content.
 func (u ExchangeContent) Hash() (Hash, error) {
 	hash, err := poseidon.Hash([]*big.Int{
+		// fields ordered alphabetically regarding their JSON key
 		u.Address.BigInt(),
-		u.TotalSwapVolume,
-		u.SwapVolumeYear,
 		u.SwapVolumeHalfYear,
+		u.SwapVolumeYear,
+		u.TotalSwapVolume,
 	})
 	if err != nil {
 		return Hash{}, err

--- a/pkg/zkcertificate/certificate_kyc.go
+++ b/pkg/zkcertificate/certificate_kyc.go
@@ -158,19 +158,20 @@ func (c KYCContent) Standard() Standard {
 // Hash computes and returns the hash of the KYCContent instance.
 func (c KYCContent) Hash() (Hash, error) {
 	hash, err := poseidon.Hash([]*big.Int{
-		c.Surname.BigInt(),
+		// fields ordered alphabetically regarding their JSON key
+		c.Citizenship.BigInt(),
+		c.Country.BigInt(),
+		big.NewInt(int64(c.DayOfBirth)),
 		c.Forename.BigInt(),
 		c.MiddleName.BigInt(),
-		big.NewInt(int64(c.YearOfBirth)),
 		big.NewInt(int64(c.MonthOfBirth)),
-		big.NewInt(int64(c.DayOfBirth)),
-		big.NewInt(int64(c.VerificationLevel)),
-		c.StreetAndNumber.BigInt(),
 		c.Postcode.BigInt(),
-		c.Town.BigInt(),
 		c.Region.BigInt(),
-		c.Country.BigInt(),
-		c.Citizenship.BigInt(),
+		c.StreetAndNumber.BigInt(),
+		c.Surname.BigInt(),
+		c.Town.BigInt(),
+		big.NewInt(int64(c.VerificationLevel)),
+		big.NewInt(int64(c.YearOfBirth)),
 	})
 	if err != nil {
 		return Hash{}, err
@@ -207,13 +208,14 @@ func (v KYCVerificationLevel) MarshalText() (text []byte, err error) {
 // IDHash computes and returns a user's ID hash for registration of the HumanID salt hash.
 func (c *KYCContent) IDHash() (Hash, error) {
 	hash, err := poseidon.Hash([]*big.Int{
-		c.Surname.BigInt(),
+		// fields ordered alphabetically regarding their JSON key
+		c.Citizenship.BigInt(),
+		big.NewInt(int64(c.DayOfBirth)),
 		c.Forename.BigInt(),
 		c.MiddleName.BigInt(),
-		big.NewInt(int64(c.YearOfBirth)),
 		big.NewInt(int64(c.MonthOfBirth)),
-		big.NewInt(int64(c.DayOfBirth)),
-		c.Citizenship.BigInt(),
+		c.Surname.BigInt(),
+		big.NewInt(int64(c.YearOfBirth)),
 	})
 	if err != nil {
 		return Hash{}, fmt.Errorf("compute id hash: %w", err)

--- a/pkg/zkcertificate/certificate_kyc_test.go
+++ b/pkg/zkcertificate/certificate_kyc_test.go
@@ -125,7 +125,7 @@ func TestKYCContent_Hash(t *testing.T) {
 
 	hash, err := kycContent.Hash()
 	require.NoError(t, err)
-	require.Equal(t, mustHashFromString("17914719627421525808158970735216338105805814372033137774126563568134622504748"), hash)
+	require.Equal(t, mustHashFromString("13498937448046187479975980844060005602014574276619662435996314654414855730267"), hash)
 }
 
 func mustHashFromString(s string) zkcertificate.Hash {
@@ -156,5 +156,5 @@ func TestKYCContent_IDHash(t *testing.T) {
 
 	idHash, err := kycContent.IDHash()
 	require.NoError(t, err)
-	require.Equal(t, mustHashFromString("2631591587246391270888637927706583337682035735548049498259193277656977470874"), idHash)
+	require.Equal(t, mustHashFromString("5606249467514511053794405094500185048153115639175989255899284975583206743707"), idHash)
 }

--- a/pkg/zkcertificate/certificate_rey.go
+++ b/pkg/zkcertificate/certificate_rey.go
@@ -88,11 +88,12 @@ type REYContent struct {
 // Hash implements Content.
 func (c REYContent) Hash() (Hash, error) {
 	hash, err := poseidon.Hash([]*big.Int{
-		c.XID.BigInt(),
-		c.XUsername.BigInt(),
+		// fields ordered alphabetically regarding their JSON key
+		new(big.Int).SetUint64(uint64(c.REYFaction)),
 		new(big.Int).SetUint64(uint64(c.REYScoreAll)),
 		new(big.Int).SetUint64(uint64(c.REYScoreGalactica)),
-		new(big.Int).SetUint64(uint64(c.REYFaction)),
+		c.XID.BigInt(),
+		c.XUsername.BigInt(),
 	})
 	if err != nil {
 		return Hash{}, err

--- a/pkg/zkcertificate/certificate_twitter.go
+++ b/pkg/zkcertificate/certificate_twitter.go
@@ -106,10 +106,11 @@ func (t TwitterContent) Hash() (Hash, error) {
 	}
 
 	hash, err := poseidon.Hash([]*big.Int{
+		// fields ordered alphabetically regarding their JSON key
 		big.NewInt(t.CreatedAt),
-		t.ID.BigInt(),
 		new(big.Int).SetUint64(uint64(t.FollowersCount)),
 		new(big.Int).SetUint64(uint64(t.FollowingCount)),
+		t.ID.BigInt(),
 		new(big.Int).SetUint64(uint64(t.ListedCount)),
 		new(big.Int).SetUint64(uint64(t.TweetCount)),
 		t.Username.BigInt(),


### PR DESCRIPTION
Changed the ordering of fields for poseidon hashes to be alphabetical for consistency across zkCert types.
Also adjusted test vectors accordingly.
This matches the changes in the TS SDK https://github.com/Galactica-corp/galactica-monorepo/pull/76