### PR TITLE
issueZKCert: fixed issuing from additional account

### DIFF
--- a/cmd/issueZKCert.go
+++ b/cmd/issueZKCert.go
@@ -291,12 +291,12 @@ func ensureProviderIsGuardian(
 		return fmt.Errorf("bind guardian registry contract: %w", err)
 	}
 
-	guardian, err := guardianRegistry.Guardians(&bind.CallOpts{Context: ctx}, providerAddress)
+	whitelisted, err := guardianRegistry.IsWhitelisted(&bind.CallOpts{Context: ctx}, providerAddress)
 	if err != nil {
 		return fmt.Errorf("retrieve guardian whitelist status: %w", err)
 	}
 
-	if !guardian.Whitelisted {
+	if !whitelisted {
 		return fmt.Errorf("provider %s is not a guardian yet", providerAddress)
 	}
 


### PR DESCRIPTION
Previously the guardians-sdk called a smart contract function that only returns the whitelist status of guardian admin accounts.
When the guardian used an additional issuer account it returned the error `ensure provider is guardian: provider 0x... is not a guardian`.

This PR fixes the issue by calling the more general smart contract function.