### PR TITLE
feat: Add Blum Certificate Standard (GIP-8)

### DIFF
--- a/pkg/zkcertificate/certificate.go
+++ b/pkg/zkcertificate/certificate.go
@@ -404,6 +404,13 @@ func decodeCertificateContent(
 		}
 
 		return content, nil
+	case StandardBlum:
+		var content BlumContent
+		if err := json.Unmarshal(certificateContent, &content); err != nil {
+			return nil, fmt.Errorf("decode blum certificate content json: %w", err)
+		}
+
+		return content, nil
 	default:
 		return nil, fmt.Errorf("unsupported certificate standard %s", certificateStandard)
 	}

--- a/pkg/zkcertificate/certificate_blum.go
+++ b/pkg/zkcertificate/certificate_blum.go
@@ -1,0 +1,81 @@
+// Copyright © 2025 Galactica Network
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package zkcertificate
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/iden3/go-iden3-crypto/v2/poseidon"
+	"github.com/shopspring/decimal"
+
+	"github.com/galactica-corp/guardians-sdk/v4/internal/validation"
+)
+
+// BlumContent represents the data for verification of a Blum account.
+type BlumContent struct {
+	TelegramID    int64           `json:"telegramId" validate:"required"`
+	ActivityScore decimal.Decimal `json:"activityScore" validate:"required"`
+	SybilScore    decimal.Decimal `json:"sybilScore" validate:"required"`
+}
+
+func (b BlumContent) Validate() error {
+	return validation.Validate.Struct(b)
+}
+
+// UnmarshalJSON implements [json.Unmarshaler].
+func (b *BlumContent) UnmarshalJSON(data []byte) error {
+	type Alias BlumContent
+
+	var alias Alias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+
+	if err := (*BlumContent)(&alias).Validate(); err != nil {
+		return fmt.Errorf("validate: %w", err)
+	}
+
+	*b = BlumContent(alias)
+	return nil
+}
+
+// Hash implements Content.
+func (b BlumContent) Hash() (Hash, error) {
+	hash, err := poseidon.Hash([]*big.Int{
+		// fields ordered alphabetically regarding their JSON key
+		scoreToFixedPoint(b.ActivityScore, 18),
+		scoreToFixedPoint(b.SybilScore, 18),
+		big.NewInt(b.TelegramID),
+	})
+	if err != nil {
+		return Hash{}, err
+	}
+
+	return HashFromBigInt(hash), nil
+}
+
+// scoreToFixedPoint converts a decimal score to a big.Int by scaling with 10^decimals
+// to preserve decimal precision for ZK-proof compatibility.
+func scoreToFixedPoint(score decimal.Decimal, decimals int) *big.Int {
+	return score.Shift(int32(decimals)).BigInt()
+}
+
+// Standard implements Content. It always returns StandardBlum.
+func (b BlumContent) Standard() Standard {
+	return StandardBlum
+}

--- a/pkg/zkcertificate/certificate_blum_test.go
+++ b/pkg/zkcertificate/certificate_blum_test.go
@@ -1,0 +1,281 @@
+// Copyright © 2025 Galactica Network
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package zkcertificate
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlumContent_UnmarshalJSON tests various scenarios for unmarshalling JSON into BlumContent
+func TestBlumContent_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		jsonData    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "Missing Required Field - TelegramID",
+			jsonData: `{
+				"sybilScore": 85,
+				"activityScore": 90
+			}`,
+			wantErr:     true,
+			errContains: "required",
+		},
+		{
+			name: "Missing Required Field - SybilScore",
+			jsonData: `{
+				"telegramId": 123456789,
+				"activityScore": "90.5"
+			}`,
+			wantErr:     true,
+			errContains: "required",
+		},
+		{
+			name: "Missing Required Field - ActivityScore",
+			jsonData: `{
+				"telegramId": 123456789,
+				"sybilScore": "85.3"
+			}`,
+			wantErr:     true,
+			errContains: "required",
+		},
+		{
+			name: "Valid JSON - All Fields",
+			jsonData: `{
+				"telegramId": 123456789,
+				"sybilScore": "85.5",
+				"activityScore": "90.75"
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "Valid JSON - Zero Scores",
+			jsonData: `{
+				"telegramId": 123456789,
+				"sybilScore": "0.0",
+				"activityScore": "0.0"
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "Valid JSON - Large TelegramID",
+			jsonData: `{
+				"telegramId": 9999999999,
+				"sybilScore": "100.0",
+				"activityScore": "100.0"
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "Valid JSON - Decimal Precision",
+			jsonData: `{
+				"telegramId": 1305035200,
+				"activityScore": "40.06289271058492",
+				"sybilScore": "0.20000000298023224"
+			}`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var content BlumContent
+			err := json.Unmarshal([]byte(tt.jsonData), &content)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestBlumContent_Standard tests the Standard method.
+func TestBlumContent_Standard(t *testing.T) {
+	content := BlumContent{}
+	standard := content.Standard()
+	require.Equal(t, StandardBlum, standard)
+}
+
+// TestBlumContent_Hash tests the Hash method with different input combinations.
+func TestBlumContent_Hash(t *testing.T) {
+	tests := []struct {
+		name          string
+		telegramID    int64
+		sybilScore    string
+		activityScore string
+	}{
+		{
+			name:          "Basic Values",
+			telegramID:    123456789,
+			sybilScore:    "85.5",
+			activityScore: "90.75",
+		},
+		{
+			name:          "Different TelegramID",
+			telegramID:    987654321,
+			sybilScore:    "85.5",
+			activityScore: "90.75",
+		},
+		{
+			name:          "Different SybilScore",
+			telegramID:    123456789,
+			sybilScore:    "95.3",
+			activityScore: "90.75",
+		},
+		{
+			name:          "Different ActivityScore",
+			telegramID:    123456789,
+			sybilScore:    "85.5",
+			activityScore: "95.2",
+		},
+		{
+			name:          "Low Scores",
+			telegramID:    123456789,
+			sybilScore:    "1.1",
+			activityScore: "1.5",
+		},
+		{
+			name:          "High Scores",
+			telegramID:    123456789,
+			sybilScore:    "100.0",
+			activityScore: "100.0",
+		},
+		{
+			name:          "Large TelegramID",
+			telegramID:    9999999999,
+			sybilScore:    "50.5",
+			activityScore: "75.25",
+		},
+		{
+			name:          "Decimal Precision",
+			telegramID:    1305035200,
+			sybilScore:    "0.20000000298023224",
+			activityScore: "40.06289271058492",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := BlumContent{
+				TelegramID:    tt.telegramID,
+				SybilScore:    decimal.RequireFromString(tt.sybilScore),
+				ActivityScore: decimal.RequireFromString(tt.activityScore),
+			}
+
+			hash, err := content.Hash()
+			require.NoError(t, err)
+
+			// The hash value will depend on the implementation of the Hash method
+			// We're just checking that it doesn't return an error and produces a non-zero hash
+			require.NotEqual(t, Hash{}, hash)
+
+			// Verify that different inputs produce different hashes
+			// This is a basic check to ensure the hash function is working as expected
+			for _, otherTT := range tests {
+				if otherTT.name != tt.name {
+					otherContent := BlumContent{
+						TelegramID:    otherTT.telegramID,
+						SybilScore:    decimal.RequireFromString(otherTT.sybilScore),
+						ActivityScore: decimal.RequireFromString(otherTT.activityScore),
+					}
+
+					otherHash, err := otherContent.Hash()
+					require.NoError(t, err)
+
+					// If any field is different, the hash should be different
+					if tt.telegramID != otherTT.telegramID ||
+						tt.sybilScore != otherTT.sybilScore ||
+						tt.activityScore != otherTT.activityScore {
+						require.NotEqual(t, hash, otherHash,
+							"Hash for %s should be different from hash for %s", tt.name, otherTT.name)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestBlumContent_JSON_RoundTrip tests that marshaling and then unmarshalling
+// a BlumContent struct results in the same struct for different combinations of field values.
+func TestBlumContent_JSON_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name          string
+		telegramID    int64
+		sybilScore    string
+		activityScore string
+	}{
+		{
+			name:          "Basic Values",
+			telegramID:    123456789,
+			sybilScore:    "85.5",
+			activityScore: "90.75",
+		},
+		{
+			name:          "Low Scores",
+			telegramID:    123456789,
+			sybilScore:    "1.1",
+			activityScore: "1.5",
+		},
+		{
+			name:          "High Scores",
+			telegramID:    123456789,
+			sybilScore:    "100.0",
+			activityScore: "100.0",
+		},
+		{
+			name:          "Large TelegramID",
+			telegramID:    9999999999,
+			sybilScore:    "50.5",
+			activityScore: "75.25",
+		},
+		{
+			name:          "Decimal Precision",
+			telegramID:    1305035200,
+			sybilScore:    "0.20000000298023224",
+			activityScore: "40.06289271058492",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := BlumContent{
+				TelegramID:    tt.telegramID,
+				SybilScore:    decimal.RequireFromString(tt.sybilScore),
+				ActivityScore: decimal.RequireFromString(tt.activityScore),
+			}
+
+			jsonData, err := json.Marshal(original)
+			require.NoError(t, err)
+
+			var unmarshalled BlumContent
+			err = json.Unmarshal(jsonData, &unmarshalled)
+			require.NoError(t, err)
+
+			require.Equal(t, original.TelegramID, unmarshalled.TelegramID)
+			require.True(t, original.SybilScore.Equal(unmarshalled.SybilScore))
+			require.True(t, original.ActivityScore.Equal(unmarshalled.ActivityScore))
+		})
+	}
+}

--- a/pkg/zkcertificate/standard.go
+++ b/pkg/zkcertificate/standard.go
@@ -31,6 +31,7 @@ const (
 	StandardDEX        Standard = "gip5"
 	StandardCEX        Standard = "gip6"
 	StandardTelegram   Standard = "gip7"
+	StandardBlum       Standard = "gip8"
 )
 
 var allStandards = []string{
@@ -41,6 +42,7 @@ var allStandards = []string{
 	StandardDEX.String(),
 	StandardCEX.String(),
 	StandardTelegram.String(),
+	StandardBlum.String(),
 }
 
 // IsStandard returns true if given value is a valid Standard.


### PR DESCRIPTION
## Summary

Adds a new certificate standard `gip8` for [Blum](https://www.blum.io) with support for Telegram-based user verification including sybil and activity scores.

## Changes

- **New Standard**: Added `StandardBlum` (`gip8`) to the certificate standards
- **New Certificate Type**: `BlumContent` with fields:
  - `telegramId` (int64): Telegram user ID
  - `activityScore` (decimal.Decimal): User activity metric with deterministic precision
  - `sybilScore` (decimal.Decimal): Sybil resistance score with deterministic precision
- **Type Safety**: Uses `int64` for Telegram ID (per official Telegram API specification) and `decimal.Decimal` for scores (ensuring consistent parsing across implementations)
- **Precision Handling**: Converts decimal scores to big.Int with 18 decimal places for zero-knowledge proof compatibility
- **Comprehensive Tests**: Added full test coverage for JSON marshaling, hashing, and validation

## Files Modified

- `pkg/zkcertificate/standard.go` - Added StandardBlum constant
- `pkg/zkcertificate/certificate.go` - Added Blum decoder case

## Files Added

- `pkg/zkcertificate/certificate_blum.go` - BlumContent implementation
- `pkg/zkcertificate/certificate_blum_test.go` - Test suite

## Testing

All tests pass including backward compatibility with existing certificate types.

```bash
go test ./pkg/zkcertificate -v
```